### PR TITLE
Dummy GitHub action

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -1,0 +1,11 @@
+name: Dummy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Hello World
+        run: echo "Hello World"

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -1,5 +1,11 @@
 name: Dummy
 
+# It's a workaround for testing GitHub Actions on non-master branches.
+# Check the accepted answer for more details:
+# https://stackoverflow.com/questions/63362126/github-actions-how-to-run-a-workflow-created-on-a-non-master-branch-from-the-wo
+# TLDR; Workflows can't be run from non-master branches unless they have been run before.
+# If a new workflow is added it can be pushed as this file and triggered by selecting the branch in "Use workflow from".
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
It's a workaround for testing GitHub Actions on non-master branches.
Check the accepted answer for more details:
https://stackoverflow.com/questions/63362126/github-actions-how-to-run-a-workflow-created-on-a-non-master-branch-from-the-wo
TLDR; Workflows can't be run from non-master branches unless they have been run before.
If a new workflow is added it can be pushed as this file and triggered by selecting the branch in "Use workflow from".