### PR TITLE
Bugfix/GitHub actions not running

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu:latest
     steps:
       - name: Hello World
         run: echo "Hello World"

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     steps:
       - name: Hello World
         run: echo "Hello World"

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -6,6 +6,11 @@ name: Dummy
 # TLDR; Workflows can't be run from non-master branches unless they have been run before.
 # If a new workflow is added it can be pushed as this file and triggered by selecting the branch in "Use workflow from".
 
+# If the workflow is stuck in queued state check:
+# https://github.com/orgs/community/discussions/26693
+# The known cause is an unsupported image, the list of the supported ones is here:
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
If the workflow is stuck in queued state check:
https://github.com/orgs/community/discussions/26693
The known cause is an unsupported image, the list of the supported ones is here:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
